### PR TITLE
Swift 6 support

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,18 +8,21 @@ on:
     branches:
       - main
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
+
 jobs:
   test-ios:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Build and test
-        run: xcodebuild test -scheme OllamaKit -destination 'platform=iOS Simulator,name=iPhone 14 Pro'
+        run: xcodebuild test -scheme OllamaKit -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
 
   test-macos:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,9 +13,12 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
+
 jobs:
   deploy:
-    runs-on: macos-13
+    runs-on: macos-15
 
     environment:
       name: github-pages

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OllamaKit",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .macCatalyst(.v15)
+    ],
+    products: [
+        .library(
+            name: "OllamaKit",
+            targets: ["OllamaKit"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin.git", .upToNextMajor(from: "1.3.0"))
+    ],
+    targets: [
+        .target(
+            name: "OllamaKit",
+            dependencies: []),
+        .testTarget(
+            name: "OllamaKitTests",
+            dependencies: ["OllamaKit"]),
+    ]
+)

--- a/Playground/OKPlayground.xcodeproj/project.pbxproj
+++ b/Playground/OKPlayground.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhermawan.OKPlayground;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -396,7 +396,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhermawan.OKPlayground;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Playground/OKPlayground/ViewModels/ViewModel.swift
+++ b/Playground/OKPlayground/ViewModels/ViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import OllamaKit
 
 @Observable
+@MainActor
 final class ViewModel {
     var ollamaKit = OllamaKit()
     

--- a/Sources/OllamaKit/OllamaKit+Chat.swift
+++ b/Sources/OllamaKit/OllamaKit+Chat.swift
@@ -100,8 +100,8 @@ extension OllamaKit {
     /// - Returns: An `AsyncThrowingStream<OKChatResponse, Error>` emitting the live stream of chat responses from the Ollama API.
     public func chat(data: OKChatRequestData) -> AsyncThrowingStream<OKChatResponse, Error> {
         do {
-            let request = try OKRouter.chat(data: data).asURLRequest()
-            
+            let request = try OKRouter.chat(data: data).asURLRequest(with: baseURL)
+
             return OKHTTPClient.shared.stream(request: request, with: OKChatResponse.self)
         } catch {
             return AsyncThrowingStream { continuation in
@@ -197,8 +197,8 @@ extension OllamaKit {
     /// - Returns: An `AnyPublisher<OKChatResponse, Error>` emitting the live stream of chat responses from the Ollama API.
     public func chat(data: OKChatRequestData) -> AnyPublisher<OKChatResponse, Error> {
         do {
-            let request = try OKRouter.chat(data: data).asURLRequest()
-            
+            let request = try OKRouter.chat(data: data).asURLRequest(with: baseURL)
+
             return OKHTTPClient.shared.stream(request: request, with: OKChatResponse.self)
         } catch {
             return Fail(error: error).eraseToAnyPublisher()

--- a/Sources/OllamaKit/OllamaKit+CopyModel.swift
+++ b/Sources/OllamaKit/OllamaKit+CopyModel.swift
@@ -22,8 +22,8 @@ extension OllamaKit {
     /// - Parameter data: The ``OKCopyModelRequestData`` containing the details needed to copy the model.
     /// - Throws: An error if the request to copy the model fails.
     public func copyModel(data: OKCopyModelRequestData) async throws -> Void {
-        let request = try OKRouter.copyModel(data: data).asURLRequest()
-        
+        let request = try OKRouter.copyModel(data: data).asURLRequest(with: baseURL)
+
         try await OKHTTPClient.shared.send(request: request)
     }
     
@@ -48,7 +48,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<Void, Error>` that completes when the copy operation is done.
     public func copyModel(data: OKCopyModelRequestData) -> AnyPublisher<Void, Error> {
         do {
-            let request = try OKRouter.copyModel(data: data).asURLRequest()
+            let request = try OKRouter.copyModel(data: data).asURLRequest(with: baseURL)
             
             return OKHTTPClient.shared.send(request: request)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+DeleteModel.swift
+++ b/Sources/OllamaKit/OllamaKit+DeleteModel.swift
@@ -22,8 +22,8 @@ extension OllamaKit {
     /// - Parameter data: The ``OKDeleteModelRequestData`` containing the details needed to delete the model.
     /// - Throws: An error if the request to delete the model fails.
     public func deleteModel(data: OKDeleteModelRequestData) async throws -> Void {
-        let request = try OKRouter.deleteModel(data: data).asURLRequest()
-        
+        let request = try OKRouter.deleteModel(data: data).asURLRequest(with: baseURL)
+
         try await OKHTTPClient.shared.send(request: request)
     }
     
@@ -48,7 +48,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<Void, Error>` that completes when the deletion operation is done.
     public func deleteModel(data: OKDeleteModelRequestData) -> AnyPublisher<Void, Error> {
         do {
-            let request = try OKRouter.deleteModel(data: data).asURLRequest()
+            let request = try OKRouter.deleteModel(data: data).asURLRequest(with: baseURL)
             
             return OKHTTPClient.shared.send(request: request)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+Embeddings.swift
+++ b/Sources/OllamaKit/OllamaKit+Embeddings.swift
@@ -23,8 +23,8 @@ extension OllamaKit {
     /// - Returns: An ``OKEmbeddingsResponse`` containing the embeddings from the model.
     /// - Throws: An error if the request fails or the response can't be decoded.
     public func embeddings(data: OKEmbeddingsRequestData) async throws -> OKEmbeddingsResponse {
-        let request = try OKRouter.embeddings(data: data).asURLRequest()
-        
+        let request = try OKRouter.embeddings(data: data).asURLRequest(with: baseURL)
+
         return try await OKHTTPClient.shared.send(request: request, with: OKEmbeddingsResponse.self)
     }
     
@@ -49,7 +49,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<OKEmbeddingsResponse, Error>` that emits embeddings.
     public func embeddings(data: OKEmbeddingsRequestData) -> AnyPublisher<OKEmbeddingsResponse, Error> {
         do {
-            let request = try OKRouter.embeddings(data: data).asURLRequest()
+            let request = try OKRouter.embeddings(data: data).asURLRequest(with: baseURL)
             
             return OKHTTPClient.shared.send(request: request, with: OKEmbeddingsResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+Generate.swift
+++ b/Sources/OllamaKit/OllamaKit+Generate.swift
@@ -32,8 +32,8 @@ extension OllamaKit {
     /// - Returns: An `AsyncThrowingStream<OKGenerateResponse, Error>` emitting the live stream of responses from the Ollama API.
     public func generate(data: OKGenerateRequestData) -> AsyncThrowingStream<OKGenerateResponse, Error> {
         do {
-            let request = try OKRouter.generate(data: data).asURLRequest()
-            
+            let request = try OKRouter.generate(data: data).asURLRequest(with: baseURL)
+
             return OKHTTPClient.shared.stream(request: request, with: OKGenerateResponse.self)
         } catch {
             return AsyncThrowingStream { continuation in
@@ -63,7 +63,7 @@ extension OllamaKit {
     /// - Returns: An `AnyPublisher<OKGenerateResponse, Error>` emitting the live stream of responses from the Ollama API.
     public func generate(data: OKGenerateRequestData) -> AnyPublisher<OKGenerateResponse, Error> {
         do {
-            let request = try OKRouter.generate(data: data).asURLRequest()
+            let request = try OKRouter.generate(data: data).asURLRequest(with: baseURL)
             
             return OKHTTPClient.shared.stream(request: request, with: OKGenerateResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+ModelInfo.swift
+++ b/Sources/OllamaKit/OllamaKit+ModelInfo.swift
@@ -23,8 +23,8 @@ extension OllamaKit {
     /// - Returns: An ``OKModelInfoResponse`` containing detailed information about the model.
     /// - Throws: An error if the request fails or the response can't be decoded.
     public func modelInfo(data: OKModelInfoRequestData) async throws -> OKModelInfoResponse {
-        let request = try OKRouter.modelInfo(data: data).asURLRequest()
-        
+        let request = try OKRouter.modelInfo(data: data).asURLRequest(with: baseURL)
+
         return try await OKHTTPClient.shared.send(request: request, with: OKModelInfoResponse.self)
     }
     
@@ -49,7 +49,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<OKModelInfoResponse, Error>` that emits detailed information about the model.
     public func modelInfo(data: OKModelInfoRequestData) -> AnyPublisher<OKModelInfoResponse, Error> {
         do {
-            let request = try OKRouter.modelInfo(data: data).asURLRequest()
+            let request = try OKRouter.modelInfo(data: data).asURLRequest(with: baseURL)
             
             return OKHTTPClient.shared.send(request: request, with: OKModelInfoResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+Models.swift
+++ b/Sources/OllamaKit/OllamaKit+Models.swift
@@ -21,8 +21,8 @@ extension OllamaKit {
     /// - Returns: An ``OKModelResponse`` object listing the available models.
     /// - Throws: An error if the request fails or the response can't be decoded.
     public func models() async throws -> OKModelResponse {
-        let request = try OKRouter.models.asURLRequest()
-        
+        let request = try OKRouter.models.asURLRequest(with: baseURL)
+
         return try await OKHTTPClient.shared.send(request: request, with: OKModelResponse.self)
     }
     
@@ -45,7 +45,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<OKModelResponse, Error>` that emits the list of available models.
     public func models() -> AnyPublisher<OKModelResponse, Error> {
         do {
-            let request = try OKRouter.models.asURLRequest()
+            let request = try OKRouter.models.asURLRequest(with: baseURL)
             
             return OKHTTPClient.shared.send(request: request, with: OKModelResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+PullModel.swift
+++ b/Sources/OllamaKit/OllamaKit+PullModel.swift
@@ -31,7 +31,7 @@ extension OllamaKit {
     /// - Returns: An asynchronous stream that emits ``OKPullModelResponse``.
     public func pullModel(data: OKPullModelRequestData) -> AsyncThrowingStream<OKPullModelResponse, Error> {
         do {
-            let request = try OKRouter.pullModel(data: data).asURLRequest()
+            let request = try OKRouter.pullModel(data: data).asURLRequest(with: baseURL)
 
             return OKHTTPClient.shared.stream(request: request, with: OKPullModelResponse.self)
         } catch {
@@ -67,7 +67,7 @@ extension OllamaKit {
     /// - Returns: A combine publisher that emits ``OKPullModelResponse``.
     public func pullModel(data: OKPullModelRequestData) -> AnyPublisher<OKPullModelResponse, Error> {
         do {
-            let request = try OKRouter.pullModel(data: data).asURLRequest()
+            let request = try OKRouter.pullModel(data: data).asURLRequest(with: baseURL)
 
             return OKHTTPClient.shared.stream(request: request, with: OKPullModelResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+PullModel.swift
+++ b/Sources/OllamaKit/OllamaKit+PullModel.swift
@@ -1,0 +1,78 @@
+//
+//  OllamaKit+PullModel.swift
+//
+//
+//  Created by Lukas Pistrol on 25.11.24.
+//
+
+import Combine
+import Foundation
+
+extension OllamaKit {
+    /// Establishes an asynchronous stream for pulling a model from the ollama library.
+    ///
+    /// This method will periodically yield ``OKPullModelResponse`` structures as the model is being pulled.
+    /// Depending on the size of the model and the speed of the internet connection, this process may take a while.
+    /// The stream will complete once the model has been fully pulled.
+    ///
+    /// ```swift
+    /// let ollamaKit = OllamaKit()
+    /// let reqData = OKPullModelRequestData(model: "llama3.2")
+    ///
+    /// for try await response in ollamaKit.pullModel(data: reqData) {
+    ///   print(response.status)
+    ///   if let progress = response.completed, let total = response.total {
+    ///     print("Progress: \(progress)/\(total) bytes")
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// - Parameter data: The ``OKPullModelRequestData`` used to initiate the chat streaming from the ollama library.
+    /// - Returns: An asynchronous stream that emits ``OKPullModelResponse``.
+    public func pullModel(data: OKPullModelRequestData) -> AsyncThrowingStream<OKPullModelResponse, Error> {
+        do {
+            let request = try OKRouter.pullModel(data: data).asURLRequest()
+
+            return OKHTTPClient.shared.stream(request: request, with: OKPullModelResponse.self)
+        } catch {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+
+    /// Establishes a Combine publisher for pulling a model from the ollama library.
+    ///
+    /// This method will periodically yield ``OKPullModelResponse`` structures as the model is being pulled.
+    /// Depending on the size of the model and the speed of the internet connection, this process may take a while.
+    /// The stream will complete once the model has been fully pulled.
+    ///
+    /// ```swift
+    /// let ollamaKit = OllamaKit()
+    /// let reqData = OKPullModelRequestData(model: "llama3.2")
+    ///
+    /// ollamaKit.pullModel(data: reqData)
+    ///   .sink { completion in
+    ///     // Handle completion
+    ///   } receiveValue: { response in
+    ///     print(response.status)
+    ///     if let progress = response.completed, let total = response.total {
+    ///       print("Progress: \(progress)/\(total) bytes")
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// - Parameter data: The ``OKPullModelRequestData`` used to initiate the chat streaming from the ollama library.
+    /// - Returns: A combine publisher that emits ``OKPullModelResponse``.
+    public func pullModel(data: OKPullModelRequestData) -> AnyPublisher<OKPullModelResponse, Error> {
+        do {
+            let request = try OKRouter.pullModel(data: data).asURLRequest()
+
+            return OKHTTPClient.shared.stream(request: request, with: OKPullModelResponse.self)
+        } catch {
+            return Fail(error: error).eraseToAnyPublisher()
+        }
+    }
+
+}

--- a/Sources/OllamaKit/OllamaKit+Reachable.swift
+++ b/Sources/OllamaKit/OllamaKit+Reachable.swift
@@ -21,7 +21,7 @@ extension OllamaKit {
     /// - Returns: `true` if the Ollama API is reachable, `false` otherwise.
     public func reachable() async -> Bool {
         do {
-            let request = try OKRouter.root.asURLRequest()
+            let request = try OKRouter.root.asURLRequest(with: baseURL)
             try await OKHTTPClient.shared.send(request: request)
             
             return true
@@ -47,7 +47,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<Bool, Never>` that emits `true` if the API is reachable, `false` otherwise.
     public func reachable() -> AnyPublisher<Bool, Never> {
         do {
-            let request = try OKRouter.root.asURLRequest()
+            let request = try OKRouter.root.asURLRequest(with: baseURL)
             
             return OKHTTPClient.shared.send(request: request)
                 .map { _ in true }

--- a/Sources/OllamaKit/OllamaKit.swift
+++ b/Sources/OllamaKit/OllamaKit.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Provides a streamlined way to access the Ollama API, encapsulating the complexities of network communication and data processing.
-public struct OllamaKit {
+public struct OllamaKit: Sendable {
     var router: OKRouter.Type
     var decoder: JSONDecoder = .default
     

--- a/Sources/OllamaKit/OllamaKit.swift
+++ b/Sources/OllamaKit/OllamaKit.swift
@@ -11,7 +11,8 @@ import Foundation
 public struct OllamaKit: Sendable {
     var router: OKRouter.Type
     var decoder: JSONDecoder = .default
-    
+    var baseURL: URL
+
     /// Initializes a new instance of `OllamaKit` with the default base URL for the Ollama API.
     ///
     /// ```swift
@@ -19,9 +20,8 @@ public struct OllamaKit: Sendable {
     /// ```
     public init() {
         let router = OKRouter.self
-        router.baseURL = URL(string: "http://localhost:11434")!
-        
         self.router = router
+        self.baseURL = URL(string: "http://localhost:11434")!
     }
     
     /// Initializes a new instance of `OllamaKit` with a custom base URL for the Ollama API.
@@ -34,8 +34,7 @@ public struct OllamaKit: Sendable {
     /// - Parameter baseURL: The base URL to use for API requests.
     public init(baseURL: URL) {
         let router = OKRouter.self
-        router.baseURL = baseURL
-        
         self.router = router
+        self.baseURL = baseURL
     }
 }

--- a/Sources/OllamaKit/RequestData/Completion/OKCompletionOptions.swift
+++ b/Sources/OllamaKit/RequestData/Completion/OKCompletionOptions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // A structure that encapsulates options for controlling the behavior of content generation in the Ollama API.
-public struct OKCompletionOptions: Encodable {
+public struct OKCompletionOptions: Encodable, Sendable {
     /// Optional integer to enable Mirostat sampling for controlling perplexity.
     /// (0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)
     /// Mirostat sampling helps regulate the unpredictability of the output,

--- a/Sources/OllamaKit/RequestData/OKChatRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKChatRequestData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates data for chat requests to the Ollama API.
-public struct OKChatRequestData {
+public struct OKChatRequestData: Sendable {
     private let stream: Bool
     
     /// A string representing the model identifier to be used for the chat session.
@@ -31,7 +31,7 @@ public struct OKChatRequestData {
     }
     
     /// A structure that represents a single message in the chat request.
-    public struct Message: Encodable {
+    public struct Message: Encodable, Sendable {
         /// A ``Role`` value indicating the sender of the message (system, assistant, user).
         public let role: Role
         
@@ -48,7 +48,7 @@ public struct OKChatRequestData {
         }
         
         /// An enumeration that represents the role of the message sender.
-        public enum Role: String, Encodable {
+        public enum Role: String, Encodable, Sendable {
             /// Indicates the message is from the system.
             case system
             

--- a/Sources/OllamaKit/RequestData/OKCopyModelRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKCopyModelRequestData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates the necessary data to request a model copy operation in the Ollama API.
-public struct OKCopyModelRequestData: Encodable {
+public struct OKCopyModelRequestData: Encodable, Sendable {
     /// A string representing the identifier of the source model to be copied.
     public let source: String
     

--- a/Sources/OllamaKit/RequestData/OKDeleteModelRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKDeleteModelRequestData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates the necessary data to request a model deletion in the Ollama API.
-public struct OKDeleteModelRequestData: Encodable {
+public struct OKDeleteModelRequestData: Encodable, Sendable {
     /// A string representing the identifier of the model to be deleted.
     public let name: String
     

--- a/Sources/OllamaKit/RequestData/OKEmbeddingsRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKEmbeddingsRequestData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates the data required for generating embeddings using the Ollama API.
-public struct OKEmbeddingsRequestData: Encodable {
+public struct OKEmbeddingsRequestData: Encodable, Sendable {
     /// A string representing the identifier of the model.
     public let model: String
     

--- a/Sources/OllamaKit/RequestData/OKGenerateRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKGenerateRequestData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates the data required for generating responses using the Ollama API.
-public struct OKGenerateRequestData {
+public struct OKGenerateRequestData: Sendable {
     private let stream: Bool
     
     /// A string representing the identifier of the model.

--- a/Sources/OllamaKit/RequestData/OKModelInfoRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKModelInfoRequestData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates the data necessary for requesting information about a specific model from the Ollama API.
-public struct OKModelInfoRequestData: Encodable {
+public struct OKModelInfoRequestData: Encodable, Sendable {
     /// A string representing the identifier of the model for which information is requested.
     public let name: String
     

--- a/Sources/OllamaKit/RequestData/OKPullModelRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKPullModelRequestData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates the data necessary for pulling a new model from the ollama library using the Ollama API.
-public struct OKPullModelRequestData: Encodable {
+public struct OKPullModelRequestData: Encodable, Sendable {
     private let stream: Bool
 
     /// A string representing the identifier of the model for which information is requested.

--- a/Sources/OllamaKit/RequestData/OKPullModelRequestData.swift
+++ b/Sources/OllamaKit/RequestData/OKPullModelRequestData.swift
@@ -1,0 +1,22 @@
+//
+//  OKPullModelRequestData.swift
+//
+//
+//  Created by Lukas Pistrol on 25.11.24.
+//
+
+import Foundation
+
+/// A structure that encapsulates the data necessary for pulling a new model from the ollama library using the Ollama API.
+public struct OKPullModelRequestData: Encodable {
+    private let stream: Bool
+
+    /// A string representing the identifier of the model for which information is requested.
+    public let model: String
+
+    public init(model: String) {
+        self.stream = true
+        self.model = model
+    }
+}
+

--- a/Sources/OllamaKit/Responses/Completion/OKCompletionResponse.swift
+++ b/Sources/OllamaKit/Responses/Completion/OKCompletionResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A protocol that defines the response structure for a completion request in the Ollama API.
-protocol OKCompletionResponse: Decodable {
+protocol OKCompletionResponse: Decodable, Sendable {
     /// The identifier of the model used for generating the response.
     var model: String { get }
     

--- a/Sources/OllamaKit/Responses/OKChatResponse.swift
+++ b/Sources/OllamaKit/Responses/OKChatResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents the response to a chat request from the Ollama API.
-public struct OKChatResponse: OKCompletionResponse, Decodable {
+public struct OKChatResponse: OKCompletionResponse, Decodable, Sendable {
     /// The identifier of the model that processed the request.
     public let model: String
     
@@ -44,7 +44,7 @@ public struct OKChatResponse: OKCompletionResponse, Decodable {
     public let evalDuration: Int?
     
     /// A structure that represents a single response message.
-    public struct Message: Decodable {
+    public struct Message: Decodable, Sendable {
         /// The role of the message sender (system, assistant, user).
         public var role: Role
         
@@ -55,7 +55,7 @@ public struct OKChatResponse: OKCompletionResponse, Decodable {
         public var toolCalls: [ToolCall]?
         
         /// An enumeration representing the role of the message sender.
-        public enum Role: String, Decodable {
+        public enum Role: String, Decodable, Sendable {
             /// The message is from the system.
             case system
             
@@ -67,12 +67,12 @@ public struct OKChatResponse: OKCompletionResponse, Decodable {
         }
         
         /// A structure that represents a tool call in the response.
-        public struct ToolCall: Decodable {
+        public struct ToolCall: Decodable, Sendable {
             /// An optional ``Function`` structure representing the details of the tool call.
             public let function: Function?
             
             /// A structure that represents the details of a tool call.
-            public struct Function: Decodable {
+            public struct Function: Decodable, Sendable {
                 /// The name of the tool being called.
                 public let name: String?
                 

--- a/Sources/OllamaKit/Responses/OKEmbeddingsResponse.swift
+++ b/Sources/OllamaKit/Responses/OKEmbeddingsResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents the response to an embedding request from the Ollama API.
-public struct OKEmbeddingsResponse: Decodable {
+public struct OKEmbeddingsResponse: Decodable, Sendable {
     
     /// An array of doubles representing the embeddings of the input prompt.
     public let embedding: [Double]?

--- a/Sources/OllamaKit/Responses/OKGenerateResponse.swift
+++ b/Sources/OllamaKit/Responses/OKGenerateResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents the response to a content generation request from the Ollama API.
-public struct OKGenerateResponse: OKCompletionResponse, Decodable {
+public struct OKGenerateResponse: OKCompletionResponse, Decodable, Sendable {
     /// The identifier of the model used for generating the content.
     public let model: String
     

--- a/Sources/OllamaKit/Responses/OKModelInfoResponse.swift
+++ b/Sources/OllamaKit/Responses/OKModelInfoResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents the response containing information about a specific model from the Ollama API.
-public struct OKModelInfoResponse: Decodable {
+public struct OKModelInfoResponse: Decodable, Sendable {
     /// A string detailing the licensing information for the model.
     public let license: String
     

--- a/Sources/OllamaKit/Responses/OKModelResponse.swift
+++ b/Sources/OllamaKit/Responses/OKModelResponse.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 /// A structure that represents the available models from the Ollama API.
-public struct OKModelResponse: Decodable {
+public struct OKModelResponse: Decodable, Sendable {
     /// An array of ``Model`` instances, each representing a specific model available in the Ollama API.
     public let models: [Model]
     
     /// A structure that details individual models.
-    public struct Model: Decodable {
+    public struct Model: Decodable, Sendable {
         /// A string representing the name of the model.
         public let name: String
         
@@ -30,7 +30,7 @@ public struct OKModelResponse: Decodable {
         public let details: ModelDetails
 
         /// A structure that represents the details of the model.
-        public struct ModelDetails: Decodable {
+        public struct ModelDetails: Decodable, Sendable {
             /// The format of the model. E.g. "gguf".
             public let format: String
 

--- a/Sources/OllamaKit/Responses/OKModelResponse.swift
+++ b/Sources/OllamaKit/Responses/OKModelResponse.swift
@@ -25,5 +25,26 @@ public struct OKModelResponse: Decodable {
         
         /// A `Date` representing the last modification date of the model.
         public let modifiedAt: Date
+
+        /// The details about the model.
+        public let details: ModelDetails
+
+        /// A structure that represents the details of the model.
+        public struct ModelDetails: Decodable {
+            /// The format of the model. E.g. "gguf".
+            public let format: String
+
+            /// The family of the model. E.g. "llama".
+            public let family: String
+
+            /// The parameter size of the model. E.g. "8.0B".
+            public let parameterSize: String
+
+            /// The quantization level of the model. E.g. "Q4_0".
+            public let quantizationLevel: String
+
+            /// All the families of the model. E.g. ["llama", "phi3"].
+            public let families: [String]?
+        }
     }
 }

--- a/Sources/OllamaKit/Responses/OKPullModelResponse.swift
+++ b/Sources/OllamaKit/Responses/OKPullModelResponse.swift
@@ -1,0 +1,23 @@
+//
+//  OKPullModelResponse.swift
+//
+//
+//  Created by Lukas Pistrol on 25.11.24.
+//
+
+import Foundation
+
+/// The response model for pulling a new model from the ollama library.
+public struct OKPullModelResponse: Decodable {
+    /// The current status.
+    public let status: String
+
+    /// The digest hash of the current file.
+    public let digest: String?
+
+    /// The size of the current file.
+    public let total: Int?
+
+    /// The number of bytes that have been completed.
+    public let completed: Int?
+}

--- a/Sources/OllamaKit/Responses/OKPullModelResponse.swift
+++ b/Sources/OllamaKit/Responses/OKPullModelResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The response model for pulling a new model from the ollama library.
-public struct OKPullModelResponse: Decodable {
+public struct OKPullModelResponse: Decodable, Sendable {
     /// The current status.
     public let status: String
 

--- a/Sources/OllamaKit/Utils/OKJSONValue.swift
+++ b/Sources/OllamaKit/Utils/OKJSONValue.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum OKJSONValue: Codable {
+public enum OKJSONValue: Codable, Sendable {
     case string(String)
     case number(Double)
     case integer(Int)

--- a/Sources/OllamaKit/Utils/OKRouter.swift
+++ b/Sources/OllamaKit/Utils/OKRouter.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 internal enum OKRouter {
-    static var baseURL = URL(string: "http://localhost:11434")!
-    
     case root
     case models
     case modelInfo(data: OKModelInfoRequestData)
@@ -72,8 +70,8 @@ internal enum OKRouter {
 }
 
 extension OKRouter {
-    func asURLRequest() throws -> URLRequest {
-        let url = OKRouter.baseURL.appendingPathComponent(path)
+    func asURLRequest(with baseURL: URL) throws -> URLRequest {
+        let url = baseURL.appendingPathComponent(path)
         
         var request = URLRequest(url: url)
         request.httpMethod = method

--- a/Sources/OllamaKit/Utils/OKRouter.swift
+++ b/Sources/OllamaKit/Utils/OKRouter.swift
@@ -17,6 +17,7 @@ internal enum OKRouter {
     case chat(data: OKChatRequestData)
     case copyModel(data: OKCopyModelRequestData)
     case deleteModel(data: OKDeleteModelRequestData)
+    case pullModel(data: OKPullModelRequestData)
     case embeddings(data: OKEmbeddingsRequestData)
     
     internal var path: String {
@@ -35,6 +36,8 @@ internal enum OKRouter {
             return "/api/copy"
         case .deleteModel:
             return "/api/delete"
+        case .pullModel:
+            return "/api/pull"
         case .embeddings:
             return "/api/embeddings"
         }
@@ -56,6 +59,8 @@ internal enum OKRouter {
             return "POST"
         case .deleteModel:
             return "DELETE"
+        case .pullModel:
+            return "POST"
         case .embeddings:
             return "POST"
         }
@@ -84,6 +89,8 @@ extension OKRouter {
         case .copyModel(let data):
             request.httpBody = try JSONEncoder.default.encode(data)
         case .deleteModel(let data):
+            request.httpBody = try JSONEncoder.default.encode(data)
+        case .pullModel(let data):
             request.httpBody = try JSONEncoder.default.encode(data)
         case .embeddings(let data):
             request.httpBody = try JSONEncoder.default.encode(data)

--- a/Sources/OllamaKit/Utils/StreamingDelegate.swift
+++ b/Sources/OllamaKit/Utils/StreamingDelegate.swift
@@ -5,10 +5,10 @@
 //  Created by Kevin Hermawan on 09/06/24.
 //
 
-import Combine
+@preconcurrency import Combine
 import Foundation
 
-internal class StreamingDelegate: NSObject, URLSessionDataDelegate {
+internal class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     private let subject = PassthroughSubject<Data, URLError>()
     
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {


### PR DESCRIPTION
This PR changes the `swift-tools-version` to Swift 6.

Along with this transition a couple of things needed to change:

- Conform models to `Sendable` to ensure thread-safety.
- Get rid of unneeded static var `baseURL` that is not thread-safe. Moved it to `OllamaKit` and passed it to `OKRouter` as an argument.
- Updated the Playground Project's `ViewModel` to run UI changes on the `@MainActor`.
- Added `details` to `OKModelResponse`.
- Update GitHub workflows to run on `macos-15` and use `Xcode 16.1`.

> There is a similar PR (#38) ongoing but for some reason they changed most `Double` occurrences to `Float` which changes the public API. I'm happy to report that this PR does not change the public API!