### PR TITLE
Add bearer token support to API requests

### DIFF
--- a/Sources/OllamaKit/OllamaKit+Chat.swift
+++ b/Sources/OllamaKit/OllamaKit+Chat.swift
@@ -100,7 +100,7 @@ extension OllamaKit {
     /// - Returns: An `AsyncThrowingStream<OKChatResponse, Error>` emitting the live stream of chat responses from the Ollama API.
     public func chat(data: OKChatRequestData) -> AsyncThrowingStream<OKChatResponse, Error> {
         do {
-            let request = try OKRouter.chat(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.chat(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
             return OKHTTPClient.shared.stream(request: request, with: OKChatResponse.self)
         } catch {
@@ -197,7 +197,7 @@ extension OllamaKit {
     /// - Returns: An `AnyPublisher<OKChatResponse, Error>` emitting the live stream of chat responses from the Ollama API.
     public func chat(data: OKChatRequestData) -> AnyPublisher<OKChatResponse, Error> {
         do {
-            let request = try OKRouter.chat(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.chat(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
             return OKHTTPClient.shared.stream(request: request, with: OKChatResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+CopyModel.swift
+++ b/Sources/OllamaKit/OllamaKit+CopyModel.swift
@@ -22,7 +22,7 @@ extension OllamaKit {
     /// - Parameter data: The ``OKCopyModelRequestData`` containing the details needed to copy the model.
     /// - Throws: An error if the request to copy the model fails.
     public func copyModel(data: OKCopyModelRequestData) async throws -> Void {
-        let request = try OKRouter.copyModel(data: data).asURLRequest(with: baseURL)
+        let request = try OKRouter.copyModel(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
         try await OKHTTPClient.shared.send(request: request)
     }
@@ -48,7 +48,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<Void, Error>` that completes when the copy operation is done.
     public func copyModel(data: OKCopyModelRequestData) -> AnyPublisher<Void, Error> {
         do {
-            let request = try OKRouter.copyModel(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.copyModel(data: data).asURLRequest(with: baseURL, with: bearerToken)
             
             return OKHTTPClient.shared.send(request: request)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+DeleteModel.swift
+++ b/Sources/OllamaKit/OllamaKit+DeleteModel.swift
@@ -22,7 +22,7 @@ extension OllamaKit {
     /// - Parameter data: The ``OKDeleteModelRequestData`` containing the details needed to delete the model.
     /// - Throws: An error if the request to delete the model fails.
     public func deleteModel(data: OKDeleteModelRequestData) async throws -> Void {
-        let request = try OKRouter.deleteModel(data: data).asURLRequest(with: baseURL)
+        let request = try OKRouter.deleteModel(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
         try await OKHTTPClient.shared.send(request: request)
     }
@@ -48,7 +48,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<Void, Error>` that completes when the deletion operation is done.
     public func deleteModel(data: OKDeleteModelRequestData) -> AnyPublisher<Void, Error> {
         do {
-            let request = try OKRouter.deleteModel(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.deleteModel(data: data).asURLRequest(with: baseURL, with: bearerToken)
             
             return OKHTTPClient.shared.send(request: request)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+Embeddings.swift
+++ b/Sources/OllamaKit/OllamaKit+Embeddings.swift
@@ -23,7 +23,7 @@ extension OllamaKit {
     /// - Returns: An ``OKEmbeddingsResponse`` containing the embeddings from the model.
     /// - Throws: An error if the request fails or the response can't be decoded.
     public func embeddings(data: OKEmbeddingsRequestData) async throws -> OKEmbeddingsResponse {
-        let request = try OKRouter.embeddings(data: data).asURLRequest(with: baseURL)
+        let request = try OKRouter.embeddings(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
         return try await OKHTTPClient.shared.send(request: request, with: OKEmbeddingsResponse.self)
     }
@@ -49,7 +49,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<OKEmbeddingsResponse, Error>` that emits embeddings.
     public func embeddings(data: OKEmbeddingsRequestData) -> AnyPublisher<OKEmbeddingsResponse, Error> {
         do {
-            let request = try OKRouter.embeddings(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.embeddings(data: data).asURLRequest(with: baseURL, with: bearerToken)
             
             return OKHTTPClient.shared.send(request: request, with: OKEmbeddingsResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+Generate.swift
+++ b/Sources/OllamaKit/OllamaKit+Generate.swift
@@ -32,7 +32,7 @@ extension OllamaKit {
     /// - Returns: An `AsyncThrowingStream<OKGenerateResponse, Error>` emitting the live stream of responses from the Ollama API.
     public func generate(data: OKGenerateRequestData) -> AsyncThrowingStream<OKGenerateResponse, Error> {
         do {
-            let request = try OKRouter.generate(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.generate(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
             return OKHTTPClient.shared.stream(request: request, with: OKGenerateResponse.self)
         } catch {
@@ -63,7 +63,7 @@ extension OllamaKit {
     /// - Returns: An `AnyPublisher<OKGenerateResponse, Error>` emitting the live stream of responses from the Ollama API.
     public func generate(data: OKGenerateRequestData) -> AnyPublisher<OKGenerateResponse, Error> {
         do {
-            let request = try OKRouter.generate(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.generate(data: data).asURLRequest(with: baseURL, with: bearerToken)
             
             return OKHTTPClient.shared.stream(request: request, with: OKGenerateResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+ModelInfo.swift
+++ b/Sources/OllamaKit/OllamaKit+ModelInfo.swift
@@ -23,7 +23,7 @@ extension OllamaKit {
     /// - Returns: An ``OKModelInfoResponse`` containing detailed information about the model.
     /// - Throws: An error if the request fails or the response can't be decoded.
     public func modelInfo(data: OKModelInfoRequestData) async throws -> OKModelInfoResponse {
-        let request = try OKRouter.modelInfo(data: data).asURLRequest(with: baseURL)
+        let request = try OKRouter.modelInfo(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
         return try await OKHTTPClient.shared.send(request: request, with: OKModelInfoResponse.self)
     }
@@ -49,7 +49,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<OKModelInfoResponse, Error>` that emits detailed information about the model.
     public func modelInfo(data: OKModelInfoRequestData) -> AnyPublisher<OKModelInfoResponse, Error> {
         do {
-            let request = try OKRouter.modelInfo(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.modelInfo(data: data).asURLRequest(with: baseURL, with: bearerToken)
             
             return OKHTTPClient.shared.send(request: request, with: OKModelInfoResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+Models.swift
+++ b/Sources/OllamaKit/OllamaKit+Models.swift
@@ -21,7 +21,7 @@ extension OllamaKit {
     /// - Returns: An ``OKModelResponse`` object listing the available models.
     /// - Throws: An error if the request fails or the response can't be decoded.
     public func models() async throws -> OKModelResponse {
-        let request = try OKRouter.models.asURLRequest(with: baseURL)
+        let request = try OKRouter.models.asURLRequest(with: baseURL, with: bearerToken)
 
         return try await OKHTTPClient.shared.send(request: request, with: OKModelResponse.self)
     }
@@ -45,7 +45,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<OKModelResponse, Error>` that emits the list of available models.
     public func models() -> AnyPublisher<OKModelResponse, Error> {
         do {
-            let request = try OKRouter.models.asURLRequest(with: baseURL)
+            let request = try OKRouter.models.asURLRequest(with: baseURL, with: bearerToken)
             
             return OKHTTPClient.shared.send(request: request, with: OKModelResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+PullModel.swift
+++ b/Sources/OllamaKit/OllamaKit+PullModel.swift
@@ -31,7 +31,7 @@ extension OllamaKit {
     /// - Returns: An asynchronous stream that emits ``OKPullModelResponse``.
     public func pullModel(data: OKPullModelRequestData) -> AsyncThrowingStream<OKPullModelResponse, Error> {
         do {
-            let request = try OKRouter.pullModel(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.pullModel(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
             return OKHTTPClient.shared.stream(request: request, with: OKPullModelResponse.self)
         } catch {
@@ -67,7 +67,7 @@ extension OllamaKit {
     /// - Returns: A combine publisher that emits ``OKPullModelResponse``.
     public func pullModel(data: OKPullModelRequestData) -> AnyPublisher<OKPullModelResponse, Error> {
         do {
-            let request = try OKRouter.pullModel(data: data).asURLRequest(with: baseURL)
+            let request = try OKRouter.pullModel(data: data).asURLRequest(with: baseURL, with: bearerToken)
 
             return OKHTTPClient.shared.stream(request: request, with: OKPullModelResponse.self)
         } catch {

--- a/Sources/OllamaKit/OllamaKit+Reachable.swift
+++ b/Sources/OllamaKit/OllamaKit+Reachable.swift
@@ -21,7 +21,7 @@ extension OllamaKit {
     /// - Returns: `true` if the Ollama API is reachable, `false` otherwise.
     public func reachable() async -> Bool {
         do {
-            let request = try OKRouter.root.asURLRequest(with: baseURL)
+            let request = try OKRouter.root.asURLRequest(with: baseURL, with: bearerToken)
             try await OKHTTPClient.shared.send(request: request)
             
             return true
@@ -47,7 +47,7 @@ extension OllamaKit {
     /// - Returns: A `AnyPublisher<Bool, Never>` that emits `true` if the API is reachable, `false` otherwise.
     public func reachable() -> AnyPublisher<Bool, Never> {
         do {
-            let request = try OKRouter.root.asURLRequest(with: baseURL)
+            let request = try OKRouter.root.asURLRequest(with: baseURL, with: bearerToken)
             
             return OKHTTPClient.shared.send(request: request)
                 .map { _ in true }

--- a/Sources/OllamaKit/OllamaKit.swift
+++ b/Sources/OllamaKit/OllamaKit.swift
@@ -12,16 +12,15 @@ public struct OllamaKit: Sendable {
     var router: OKRouter.Type
     var decoder: JSONDecoder = .default
     var baseURL: URL
+    var bearerToken: String?
 
-    /// Initializes a new instance of `OllamaKit` with the default base URL for the Ollama API.
+    /// Initializes a new instance of `OllamaKit` with the default base URL and no bearer token for the Ollama API.
     ///
     /// ```swift
     /// let ollamaKit = OllamaKit()
     /// ```
     public init() {
-        let router = OKRouter.self
-        self.router = router
-        self.baseURL = URL(string: "http://localhost:11434")!
+        self.init(baseURL: URL(string: "http://localhost:11434")!, bearerToken: nil)
     }
     
     /// Initializes a new instance of `OllamaKit` with a custom base URL for the Ollama API.
@@ -33,8 +32,35 @@ public struct OllamaKit: Sendable {
     ///
     /// - Parameter baseURL: The base URL to use for API requests.
     public init(baseURL: URL) {
+        self.init(baseURL: baseURL, bearerToken: nil)
+    }
+    
+    /// Initializes a new instance of `OllamaKit` with a bearer token for the Ollama API.
+    ///
+    /// ```swift
+    /// let bearerToken = "super-sected-token"
+    /// let ollamaKit = OllamaKit(bearerToken: bearerToken)
+    /// ```
+    ///
+    /// - Parameter bearerToken: The bearer token to use for API requests.
+    public init(bearerToken: String) {
+        self.init(baseURL: URL(string: "http://localhost:11434")!, bearerToken: bearerToken)
+    }
+    
+    /// Initializes a new instance of `OllamaKit` with a custom base URL and bearer token for the Ollama API.
+    ///
+    /// ```swift
+    /// let bearerToken = "super-sected-token"
+    /// let customBaseURL = URL(string: "https://api.customollama.com")!
+    /// let ollamaKit = OllamaKit(baseURL: customBaseURL, bearerToken: bearerToken)
+    /// ```
+    ///
+    /// - Parameter baseURL: The base URL to use for API requests.
+    /// - Parameter bearerToken: The bearer token to use for API requests. 
+    public init(baseURL: URL, bearerToken: String?) {
         let router = OKRouter.self
         self.router = router
         self.baseURL = baseURL
+        self.bearerToken = bearerToken
     }
 }

--- a/Sources/OllamaKit/Utils/OKRouter.swift
+++ b/Sources/OllamaKit/Utils/OKRouter.swift
@@ -20,47 +20,47 @@ internal enum OKRouter {
     
     internal var path: String {
         switch self {
-        case .root:
-            return "/"
-        case .models:
-            return "/api/tags"
-        case .modelInfo:
-            return "/api/show"
-        case .generate:
-            return "/api/generate"
-        case .chat:
-            return "/api/chat"
-        case .copyModel:
-            return "/api/copy"
-        case .deleteModel:
-            return "/api/delete"
-        case .pullModel:
-            return "/api/pull"
-        case .embeddings:
-            return "/api/embeddings"
+            case .root:
+                return "/"
+            case .models:
+                return "/api/tags"
+            case .modelInfo:
+                return "/api/show"
+            case .generate:
+                return "/api/generate"
+            case .chat:
+                return "/api/chat"
+            case .copyModel:
+                return "/api/copy"
+            case .deleteModel:
+                return "/api/delete"
+            case .pullModel:
+                return "/api/pull"
+            case .embeddings:
+                return "/api/embeddings"
         }
     }
     
     internal var method: String {
         switch self {
-        case .root:
-            return "HEAD"
-        case .models:
-            return "GET"
-        case .modelInfo:
-            return "POST"
-        case .generate:
-            return "POST"
-        case .chat:
-            return "POST"
-        case .copyModel:
-            return "POST"
-        case .deleteModel:
-            return "DELETE"
-        case .pullModel:
-            return "POST"
-        case .embeddings:
-            return "POST"
+            case .root:
+                return "HEAD"
+            case .models:
+                return "GET"
+            case .modelInfo:
+                return "POST"
+            case .generate:
+                return "POST"
+            case .chat:
+                return "POST"
+            case .copyModel:
+                return "POST"
+            case .deleteModel:
+                return "DELETE"
+            case .pullModel:
+                return "POST"
+            case .embeddings:
+                return "POST"
         }
     }
     
@@ -70,30 +70,39 @@ internal enum OKRouter {
 }
 
 extension OKRouter {
-    func asURLRequest(with baseURL: URL) throws -> URLRequest {
+    func asURLRequest(with baseURL: URL, with bearerToken: String?) throws -> URLRequest {
+        let hasBearerToken = bearerToken != nil && bearerToken!.isEmpty == false
         let url = baseURL.appendingPathComponent(path)
         
         var request = URLRequest(url: url)
         request.httpMethod = method
-        request.allHTTPHeaderFields = headers
+        
+        if (hasBearerToken) {
+            request.allHTTPHeaderFields = [
+                "Authorization": "Bearer " + bearerToken!,
+                "Content-Type": "application/json"
+            ]
+        } else {
+            request.allHTTPHeaderFields = headers
+        }
         
         switch self {
-        case .modelInfo(let data):
-            request.httpBody = try JSONEncoder.default.encode(data)
-        case .generate(let data):
-            request.httpBody = try JSONEncoder.default.encode(data)
-        case .chat(let data):
-            request.httpBody = try JSONEncoder.default.encode(data)
-        case .copyModel(let data):
-            request.httpBody = try JSONEncoder.default.encode(data)
-        case .deleteModel(let data):
-            request.httpBody = try JSONEncoder.default.encode(data)
-        case .pullModel(let data):
-            request.httpBody = try JSONEncoder.default.encode(data)
-        case .embeddings(let data):
-            request.httpBody = try JSONEncoder.default.encode(data)
-        default:
-            break
+            case .modelInfo(let data):
+                request.httpBody = try JSONEncoder.default.encode(data)
+            case .generate(let data):
+                request.httpBody = try JSONEncoder.default.encode(data)
+            case .chat(let data):
+                request.httpBody = try JSONEncoder.default.encode(data)
+            case .copyModel(let data):
+                request.httpBody = try JSONEncoder.default.encode(data)
+            case .deleteModel(let data):
+                request.httpBody = try JSONEncoder.default.encode(data)
+            case .pullModel(let data):
+                request.httpBody = try JSONEncoder.default.encode(data)
+            case .embeddings(let data):
+                request.httpBody = try JSONEncoder.default.encode(data)
+            default:
+                break
         }
         
         return request


### PR DESCRIPTION
This pull request introduces the use of bearer tokens for authentication in the OllamaKit API requests. The changes include adding a new `bearerToken` property to the `OllamaKit` struct and updating various methods to include this token when making API requests.

Key changes include:

### Authentication Enhancement
* Added a `bearerToken` property to the `OllamaKit` struct and updated the initializer to accept this token. (`Sources/OllamaKit/OllamaKit.swift`) [[1]](diffhunk://#diff-5dea63d1a641fca47aacc24e909294d8fef9cc8c7838f4c7cde1a5fe564ec04aR15-R23) [[2]](diffhunk://#diff-5dea63d1a641fca47aacc24e909294d8fef9cc8c7838f4c7cde1a5fe564ec04aR35-R64)
* Updated the `asURLRequest` method in `OKRouter` to include the bearer token in the request headers if provided. (`Sources/OllamaKit/Utils/OKRouter.swift`)

### API Request Updates
* Modified methods in various files to include the bearer token when creating URL requests:
  - `chat` method in `OllamaKit+Chat.swift` [[1]](diffhunk://#diff-47996c485409290989765415101cb7c37ba943bef283fa8bb7fdb9a07e2d18f1L103-R103) [[2]](diffhunk://#diff-47996c485409290989765415101cb7c37ba943bef283fa8bb7fdb9a07e2d18f1L200-R200)
  - `copyModel` method in `OllamaKit+CopyModel.swift` [[1]](diffhunk://#diff-ced8a2e7496affd7522012be46735872eb2174ec020fb9741e47788f2bcc0a57L25-R25) [[2]](diffhunk://#diff-ced8a2e7496affd7522012be46735872eb2174ec020fb9741e47788f2bcc0a57L51-R51)
  - `deleteModel` method in `OllamaKit+DeleteModel.swift` [[1]](diffhunk://#diff-3a0573585d205b39e261d9eb759428e88e2ac77ba7a75e804e0d0e6681f019b9L25-R25) [[2]](diffhunk://#diff-3a0573585d205b39e261d9eb759428e88e2ac77ba7a75e804e0d0e6681f019b9L51-R51)
  - `embeddings` method in `OllamaKit+Embeddings.swift` [[1]](diffhunk://#diff-dce302505b9c250213c1f9c180dc0aa6f163e012045d05677f80814cb962b417L26-R26) [[2]](diffhunk://#diff-dce302505b9c250213c1f9c180dc0aa6f163e012045d05677f80814cb962b417L52-R52)
  - `generate` method in `OllamaKit+Generate.swift` [[1]](diffhunk://#diff-54ed9d4f7cf4ae619f1ed6d3c41c2be0c91b65b3f87deb7dcb5a812d07664c7eL35-R35) [[2]](diffhunk://#diff-54ed9d4f7cf4ae619f1ed6d3c41c2be0c91b65b3f87deb7dcb5a812d07664c7eL66-R66)
  - `modelInfo` method in `OllamaKit+ModelInfo.swift` [[1]](diffhunk://#diff-d3164f311c9ce95f5f3fe6fda1789537358ad823dcfb23102dd69a4fb34495a6L26-R26) [[2]](diffhunk://#diff-d3164f311c9ce95f5f3fe6fda1789537358ad823dcfb23102dd69a4fb34495a6L52-R52)
  - `models` method in `OllamaKit+Models.swift` [[1]](diffhunk://#diff-0e96428afb5f06e4590bf2e0e18ef76671a0d1efe7cbd6496d64866868268f6eL24-R24) [[2]](diffhunk://#diff-0e96428afb5f06e4590bf2e0e18ef76671a0d1efe7cbd6496d64866868268f6eL48-R48)
  - `pullModel` method in `OllamaKit+PullModel.swift` [[1]](diffhunk://#diff-90f48a6f7fc100eb5dbad1f4d3e5dce9107fdc76579a02756348071ba46be82fL34-R34) [[2]](diffhunk://#diff-90f48a6f7fc100eb5dbad1f4d3e5dce9107fdc76579a02756348071ba46be82fL70-R70)
  - `reachable` method in `OllamaKit+Reachable.swift` [[1]](diffhunk://#diff-3df2eacaee8ef9172028465505f9d003fea49ec89db41b964e26612a928059c6L24-R24) [[2]](diffhunk://#diff-3df2eacaee8ef9172028465505f9d003fea49ec89db41b964e26612a928059c6L50-R50)

I'm still looking at this, and working on testing it, just wanted to get the initial code into PR form. 