### PR TITLE
Fix deprecated upload artifacts action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Build docs
         run: swift package --allow-writing-to-directory ./docs generate-documentation --target OllamaKit --disable-indexing --output-path ./docs --transform-for-static-hosting --hosting-base-path OllamaKit
 
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: "docs"
 
-      - uses: actions/deploy-pages@v2
+      - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
As seen in the deployment result of 5.0.8 the docs couldn't be published:

https://github.com/kevinhermawan/OllamaKit/actions/runs/13664155695/job/38201810546

This change tries to fix it.  I used inspiration from https://github.com/actions/upload-pages-artifact
But couldn't test it as I wasn't able to properly run the action on my fork & branch, hopefully this action would run on your repository.