### PR TITLE
Improve speed and cancel behaviour

### DIFF
--- a/Sources/OllamaKit/Utils/OKHTTPClient.swift
+++ b/Sources/OllamaKit/Utils/OKHTTPClient.swift
@@ -134,8 +134,8 @@ private extension OKHTTPClient {
         var isEscaped = false
         var isWithinString = false
         var nestingDepth = 0
-        var objectStartIndex = buffer.startIndex
-        
+        let objectStartIndex = buffer.startIndex
+
         for (index, byte) in buffer.enumerated() {
             let character = Character(UnicodeScalar(byte))
             

--- a/Sources/OllamaKit/Utils/OKHTTPClient.swift
+++ b/Sources/OllamaKit/Utils/OKHTTPClient.swift
@@ -116,6 +116,9 @@ internal extension OKHTTPClient {
                     .setFailureType(to: Error.self)
                     .eraseToAnyPublisher()
             }
+            .handleEvents(receiveCancel: {
+                task.cancel()
+            })
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/OllamaKit/Utils/OKHTTPClient.swift
+++ b/Sources/OllamaKit/Utils/OKHTTPClient.swift
@@ -146,9 +146,6 @@ private extension OKHTTPClient {
                 switch character {
                 case "{":
                     nestingDepth += 1
-                    if nestingDepth == 1 {
-                        objectStartIndex = index
-                    }
                 case "}":
                     nestingDepth -= 1
                     if nestingDepth == 0 {


### PR DESCRIPTION
This PR consists of two changes:

1. `OKHTTPClient.extractNextJSON()`:  
By "consuming" the whitespaces and newlines before and after a JSON token, the parsing speed has been improved a lot for long running responses. Previously each extracted JSON left back some whitespaces which had to be skipped again within the buffer.
In my tests (with a response consisting of 878 tokens sent from a "fake Ollama server", the reception of the whole response went from 7.9s to 2.3s!

2. `OKHTTPClient.stream()`:
The Combine based `stream()` method did not cancel the data task when the stream was cancelled. This could be observed when an Ollamac user pushed the cancel button, but generation still continued in the background.